### PR TITLE
Datum instead of radius

### DIFF
--- a/backplanesGMT.f
+++ b/backplanesGMT.f
@@ -21,9 +21,9 @@ C     Version 1.81 - 9 June 2022
 C           Output radius updated to double precision. This is needed on large objects with hi-resolution
 C           Ex. Moon with LRO images will only have ~0.125 m accuracy when building to 0.8 m GSD.
 C	Version 1.82 - 13 June 2022
-C		Output datum instead of radius (more accurate values at < 1m)
+C		Output elevation relative to datum instead of radius (more accurate values at < 1m)
 C	Version 1.83 - 14 June 2022
-C		Now asks for datum value
+C		Now asks for datum value. And version changed to a string.
 
       IMPLICIT NONE
 
@@ -59,7 +59,8 @@ C		Now asks for datum value
       INTEGER               K
       INTEGER               zeros
       INTEGER               NPX, NLN, T1, T2
-      real               version
+C      real               version
+      CHARACTER*80          version
     
       DOUBLE PRECISION      V0(3)
       DOUBLE PRECISION      SZ(3)
@@ -90,7 +91,7 @@ C		Now asks for datum value
       CHARACTER*72          PICT
       CHARACTER*72          PICTFILE
     
-      version = 1.83
+      version = "1.83"
       WRITE(*,*) 'Version:', version
 
       minLat = 90

--- a/backplanesGMT.f
+++ b/backplanesGMT.f
@@ -1,6 +1,6 @@
 c  Version 1.0 - 26 Sep 2019- Eric Palmer 
 c	This outputs a set of binary files of i, e, and phase
-c  gfortran phasei.f /usr/local/lib/spicelib.a COMMON.a -O2 -o ~/bin/t.phasei
+c  gfortran backplanesGMT.f /usr/local/lib/spicelib.a  /usr/local/src/v3.0.4/COMMON.a -O2 -o ~/bin/t.backplanesGMT
 c  Version 1.1 - 25 Nov 2020 - Eric E. Palmer
 c		Calculates lat/lon and outputs them also
 c	Version 1.2 - 8 June 2021 - Eric E. Palmer
@@ -20,6 +20,10 @@ C           Increased NTMP to 3001 - lets you have a Q of at least 2242 (Q=2242 
 C     Version 1.81 - 9 June 2022
 C           Output radius updated to double precision. This is needed on large objects with hi-resolution
 C           Ex. Moon with LRO images will only have ~0.125 m accuracy when building to 0.8 m GSD.
+C	Version 1.82 - 13 June 2022
+C		Output datum instead of radius (more accurate values at < 1m)
+C	Version 1.83 - 14 June 2022
+C		Now asks for datum value
 
       IMPLICIT NONE
 
@@ -77,7 +81,7 @@ C           Ex. Moon with LRO images will only have ~0.125 m accuracy when build
       REAL                  Z0
       REAL                  ang
       REAL                  lat, lon
-      DOUBLE PRECISION      dist
+      DOUBLE PRECISION      dist, datum
 
 
 
@@ -86,7 +90,7 @@ C           Ex. Moon with LRO images will only have ~0.125 m accuracy when build
       CHARACTER*72          PICT
       CHARACTER*72          PICTFILE
     
-      version = 1.81
+      version = 1.83
       WRITE(*,*) 'Version:', version
 
       minLat = 90
@@ -96,6 +100,10 @@ C           Ex. Moon with LRO images will only have ~0.125 m accuracy when build
 
       WRITE(6,*) 'Input map name (only 6 char no MAPFILES and .MAP)'
       READ(5,FMT='(A6)') MAP0
+      WRITE(6,*) 'Input datum (km) to use (read as double precision)'
+      WRITE(6,*) 'Standard for Luna is 1737.4' 
+      READ(5,*) datum
+      WRITE(6,*) 'Datum:', datum
 
       LMRKFILE='MAPFILES/'//MAP0//'.MAP'
       CALL READ_MAP(LMRKFILE,NTMP,QSZ,SCALE,V,UX,UY,UZ,HT0,AL0)
@@ -122,7 +130,7 @@ C     Do the basics for the center pixel
 C     Open the files that we will create
       LMRKFILE=MAP0//'-r.txt'
       OPEN(UNIT=10,FILE=LMRKFILE)
-      write (*,*) LMRKFILE, " has been scaled x1000, km to m"
+      write (*,*) LMRKFILE, " change to datum and scale x1000, km to m"
       write (*,*) "Be sure your input BIGMAP is in km"
 
       LMRKFILE=MAP0//'-alb.txt'
@@ -172,7 +180,7 @@ C			Lat and lon
               lon = lon + 360
           endif
           lat = asin ( localV(3)/dist) * 180/3.1415926
-          write(10,240) dist*1000
+          write(10,240) (dist-datum)*1000
           write(15,241) lon, lat
 
           if ( maxLat .LT. lat ) maxLat = lat

--- a/backplanesISIS.f
+++ b/backplanesISIS.f
@@ -1,6 +1,6 @@
 c  Version 1.0 - 26 Sep 2019- Eric Palmer 
 c	This outputs a set of binary files of i, e, and phase
-c  gfortran phasei.f /usr/local/lib/spicelib.a COMMON.a -O2 -o ~/bin/t.phasei
+c  gfortran backplanesISIS.f /usr/local/lib/spicelib.a /usr/local/src/v3.0.4/COMMON.a -O2 -o ~/bin/t.backplanesISIS
 c  Version 1.1 - 25 Nov 2020 - Eric E. Palmer
 c		Calculates lat/lon and outputs them also
 c	Version 1.2 - 8 June 2021 - Eric E. Palmer
@@ -11,6 +11,11 @@ c		Output is in list format
 c		Output file with Lon, Lat Plus channels for H, albedo, slope_pix, slope_norm
 C	Version 1.4 - 14 June 2021
 C		Outputs in matrix format
+C	Version 1.5 - 14 June 2022 
+C		Output user defined elevation relative to datum instead of radius
+C		elevation is double precision
+C		version is now a string
+C		NTMP increased from 2001 to 3001
 
       IMPLICIT NONE
 
@@ -45,7 +50,8 @@ C		Outputs in matrix format
       INTEGER               K
       INTEGER               zeros
       INTEGER               NPX, NLN, T1, T2
-      real               version
+C      real               version
+      CHARACTER*80          version
     
       DOUBLE PRECISION      V0(3)
       DOUBLE PRECISION      SZ(3)
@@ -66,7 +72,8 @@ C		Outputs in matrix format
       DOUBLE PRECISION      localV(3)
       REAL                  Z0
       REAL                  ang
-      REAL                  dist, lat, lon
+      REAL                  lat, lon
+      DOUBLE PRECISION      dist, datum
 
 
 
@@ -75,13 +82,18 @@ C		Outputs in matrix format
       CHARACTER*72          PICT
       CHARACTER*72          PICTFILE
     
-      version = 1.4
+      version = "1.5"
 
 
       WRITE(*,*) 'Version:', version
 
       WRITE(6,*) 'Input map name (only 6 char no MAPFILES and .MAP)'
       READ(5,FMT='(A6)') MAP0
+      WRITE(6,*) 'Input datum (km) to use (read as double precision)'
+      WRITE(6,*) 'Standard for Luna is 1737.4'
+      READ(5,*) datum
+      WRITE(6,*) 'Datum:', datum
+
 
       LMRKFILE='MAPFILES/'//MAP0//'.MAP'
       CALL READ_MAP(LMRKFILE,NTMP,QSZ,SCALE,V,UX,UY,UZ,HT0,AL0)
@@ -108,6 +120,8 @@ C     Do the basics for the center pixel
 C     Open the files that we will create
       LMRKFILE=MAP0//'-r.txt'
       OPEN(UNIT=10,FILE=LMRKFILE)
+      write (*,*) LMRKFILE, " change to datum and scale x1000, km to m"
+      write (*,*) "Be sure your input BIGMAP is in km"
 
       LMRKFILE=MAP0//'-alb.txt'
       OPEN(UNIT=11,FILE=LMRKFILE)
@@ -159,7 +173,7 @@ C			Lat and lon
               lon = lon + 360
           endif
           lat = asin ( localV(3)/dist) * 180/3.1415926
-          write(10,240, advance="no") dist
+          write(10,240, advance="no") (dist-datum)*1000
           write(15,240, advance="no") lon
           write(16,240, advance="no") lat
 

--- a/backplanesISIS.f
+++ b/backplanesISIS.f
@@ -15,7 +15,7 @@ C		Outputs in matrix format
       IMPLICIT NONE
 
       INTEGER               NTMP
-      PARAMETER            (NTMP=2001)
+      PARAMETER            (NTMP=3001)
 
       DOUBLE PRECISION      SCALE
       DOUBLE PRECISION      V(3)


### PR DESCRIPTION
I've updated backplanesGMT and backplanesISIS to work with elevation realtime to datum instead of radius. I also updated some other bits.

Both programs compile and I checked the output of radius, lat, and lon, and compared both programs. They appear to be working as intended.