### PR TITLE
Global stat dual output

### DIFF
--- a/globalStat.f
+++ b/globalStat.f
@@ -82,11 +82,12 @@ C		Initalize variables
       enddo
       enddo
       write (*,*) "Reading from SHAPE.TXT";
-      do i=1,360
+      do i=2,360
       do j=2,180
         z1=91-j
         z2=i-1
         CALL LATREC(1.d0,Z2*RPD(),Z1*RPD(), W)
+        write (*,*) I,J
         CALL U2VN(W,V(1,I,J),UZ(1,I,J))
       enddo
       write (*,"(A1)", advance="no") "."
@@ -99,6 +100,7 @@ C		Cycle over all images (SUMFILES)
         if(xname(1:1).eq.'!') go to 10
         if(xname(1:1).eq.'#') go to 10
         IF(xname(1:3).ne.'END') then
+          write (*,*) xname
           PICNM=XNAME(2:13)
           I=SLEN(PICNM)
           PICTFILE='./SUMFILES/'//PICNM(1:I)//'.SUM'
@@ -172,6 +174,7 @@ C         Maybe test over valid data
           go to 10
         ENDIF
       close(unit=20)
+      write (*,*) "done thinking"
 
 C     Output the file in temp grayscale and ascii
 c      open (unit=10, file='coverage.gray', access='direct', 
@@ -181,31 +184,35 @@ C     Vector formats
       open (unit=11, file=outfile)
       outfile='global-res.c3.txt'
       open (unit=12, file=outfile)
+    
+      write (*,*) "Pre grid"
 
 C     Gridded formats
-      outfile='global-cov.grid.txt'
-      open (unit=13, file=outfile)
-      outfile='global-res.grid.txt'
-      open (unit=14, file=outfile)
+C      outfile='global-cov.grid.txt'
+C      open (unit=13, file=outfile)
+C      outfile='global-res.grid.txt'
+C      open (unit=14, file=outfile)
         do j=1,181
           do i=1,360
             cline(i:i)=char(coverage(i,j))
             write (11, 99) i, 91-j, coverage(i,j)
             write (12, 98) i, 91-j, bestRes(i,j)
-            write (13, 96, advance="no") coverage(i,j)
-            write (14, 97, advance="no") bestRes(i,j)
+C            write (13, 96, advance="no") coverage(i,j)
+C            write (14, 97, advance="no") bestRes(i,j)
           enddo
-          write(10,rec=j) cline 
-          write(13) 
-          write(14) 
+c          write(10,rec=j) cline 
+C          write(13) 
+C          write(14) 
         enddo
+
+      write (*,*) "done grid"
 c      close(unit=10)
       close(unit=11)
       close(unit=12)
-      close(unit=13)
-      close(unit=14)
+C      close(unit=13)
+C      close(unit=14)
  96   format (i7)
- 97   format (f229.8)
+ 97   format (f22.8)
  98   format (2i5, f18.8)
  99   format (3i5)
 

--- a/globalStat.f
+++ b/globalStat.f
@@ -83,11 +83,10 @@ C		Initalize variables
       enddo
       write (*,*) "Reading from SHAPE.TXT";
       do i=2,360
-      do j=2,180
+      do j=1,180
         z1=91-j
         z2=i-1
         CALL LATREC(1.d0,Z2*RPD(),Z1*RPD(), W)
-        write (*,*) I,J
         CALL U2VN(W,V(1,I,J),UZ(1,I,J))
       enddo
       write (*,"(A1)", advance="no") "."
@@ -100,7 +99,6 @@ C		Cycle over all images (SUMFILES)
         if(xname(1:1).eq.'!') go to 10
         if(xname(1:1).eq.'#') go to 10
         IF(xname(1:3).ne.'END') then
-          write (*,*) xname
           PICNM=XNAME(2:13)
           I=SLEN(PICNM)
           PICTFILE='./SUMFILES/'//PICNM(1:I)//'.SUM'
@@ -174,7 +172,6 @@ C         Maybe test over valid data
           go to 10
         ENDIF
       close(unit=20)
-      write (*,*) "done thinking"
 
 C     Output the file in temp grayscale and ascii
 c      open (unit=10, file='coverage.gray', access='direct', 
@@ -185,32 +182,30 @@ C     Vector formats
       outfile='global-res.c3.txt'
       open (unit=12, file=outfile)
     
-      write (*,*) "Pre grid"
 
 C     Gridded formats
-C      outfile='global-cov.grid.txt'
-C      open (unit=13, file=outfile)
-C      outfile='global-res.grid.txt'
-C      open (unit=14, file=outfile)
+      outfile='global-cov.grid.txt'
+      open (unit=13, file=outfile)
+      outfile='global-res.grid.txt'
+      open (unit=14, file=outfile)
         do j=1,181
           do i=1,360
             cline(i:i)=char(coverage(i,j))
             write (11, 99) i, 91-j, coverage(i,j)
             write (12, 98) i, 91-j, bestRes(i,j)
-C            write (13, 96, advance="no") coverage(i,j)
-C            write (14, 97, advance="no") bestRes(i,j)
+            write (13, 96, advance="no") coverage(i,j)
+            write (14, 97, advance="no") bestRes(i,j)
           enddo
 c          write(10,rec=j) cline 
-C          write(13) 
-C          write(14) 
+          write(13, *) 
+          write(14, *) 
         enddo
 
-      write (*,*) "done grid"
 c      close(unit=10)
       close(unit=11)
       close(unit=12)
-C      close(unit=13)
-C      close(unit=14)
+      close(unit=13)
+      close(unit=14)
  96   format (i7)
  97   format (f22.8)
  98   format (2i5, f18.8)

--- a/globalStat.f
+++ b/globalStat.f
@@ -163,6 +163,8 @@ C             Add 1 rather than 15)
           enddo
           enddo
 
+          WRITE (6,*) 
+          WRITE (6,*) "PICTName	Average_angle	Average_res"
 C         Maybe test over valid data
           IF(K.NE.0) THEN
             Z6=Z6/K

--- a/globalStat.f
+++ b/globalStat.f
@@ -12,6 +12,10 @@ C     Fixed output and array index
 C	Version 2.2 - Aug 16th 2022
 C		Changed the output to go from 1-360, rather than 361
 C		The pgm is still 361
+C  Version 2.3 - Sep 12, 2022
+C     Made output in both grid and vector
+C     Complies with grid.txt or c1.txt, c2.txt etc
+C     Removed the generation of the pgm
 
 
       IMPLICIT NONE
@@ -56,7 +60,7 @@ C		The pgm is still 361
       real version
 
 C     Set limiting resolution
-      version = 2.2
+      version = 2.3
       write (*,*) "Version: ", version
       WRITE(6,*) 'Input RESLIM (km/px) Accept everything lower"'
       READ(5,*) RESLIM
@@ -158,6 +162,8 @@ C             Add 1 rather than 15)
             ENDIF
           enddo
           enddo
+
+C         Maybe test over valid data
           IF(K.NE.0) THEN
             Z6=Z6/K
             Z7=Z7/K
@@ -168,39 +174,54 @@ C             Add 1 rather than 15)
       close(unit=20)
 
 C     Output the file in temp grayscale and ascii
-      open (unit=10, file='coverage.gray', access='direct', 
-     .      recl=361, status='unknown')
-      outfile='global-cov.ll'
+c      open (unit=10, file='coverage.gray', access='direct', 
+c     .      recl=361, status='unknown')
+C     Vector formats
+      outfile='global-cov.c3.txt'
       open (unit=11, file=outfile)
-      outfile='global-res.ll'
+      outfile='global-res.c3.txt'
       open (unit=12, file=outfile)
+
+C     Gridded formats
+      outfile='global-cov.grid.txt'
+      open (unit=13, file=outfile)
+      outfile='global-res.grid.txt'
+      open (unit=14, file=outfile)
         do j=1,181
           do i=1,360
             cline(i:i)=char(coverage(i,j))
             write (11, 99) i, 91-j, coverage(i,j)
             write (12, 98) i, 91-j, bestRes(i,j)
+            write (13, 96, advance="no") coverage(i,j)
+            write (14, 97, advance="no") bestRes(i,j)
           enddo
           write(10,rec=j) cline 
+          write(13) 
+          write(14) 
         enddo
-      close(unit=10)
+c      close(unit=10)
       close(unit=11)
       close(unit=12)
+      close(unit=13)
+      close(unit=14)
+ 96   format (i7)
+ 97   format (f229.8)
  98   format (2i5, f18.8)
  99   format (3i5)
 
-      write(6,*) 
-      write(6,*) 'coverage done'
-
-
-C     Generate the PGM
-      npx=361
-      nln=181
-      infile='coverage.gray'
-      outfile='coverage_p.pgm'
-      call raw2pgm(infile,outfile,npx,nln)
-      write(6,*) 'gc coverage_p.pgm'
-      open (unit=10, file='coverage.gray', status='unknown')
-      close(unit=10, status='delete')
+c      write(6,*) 
+c      write(6,*) 'coverage done'
+c
+c
+cC     Generate the PGM
+c      npx=361
+c      nln=181
+c      infile='coverage.gray'
+c      outfile='coverage_p.pgm'
+c      call raw2pgm(infile,outfile,npx,nln)
+c      write(6,*) 'gc coverage_p.pgm'
+c      open (unit=10, file='coverage.gray', status='unknown')
+c      close(unit=10, status='delete')
 
       STOP
       END

--- a/globalStat.f
+++ b/globalStat.f
@@ -82,8 +82,8 @@ C		Initalize variables
       enddo
       enddo
       write (*,*) "Reading from SHAPE.TXT";
-      do i=2,360
-      do j=1,180
+      do i=1,360
+      do j=2,180
         z1=91-j
         z2=i-1
         CALL LATREC(1.d0,Z2*RPD(),Z1*RPD(), W)


### PR DESCRIPTION
globalStat has been tested and is performing the same as coverage_p, though it writes out 360 samples instead of 361. In coverage_p 361 is identical to 1, so no loss of information occurs. Lines 1 and 181 still have no information (0 for coverage and 9999 for resolution), but coverage_p also has 0 for lines 1 and 181, so everything is working as expected.

Ready to merge!