### PR TITLE
Initial implementation of average of Best and 2nd Best image resolutions

### DIFF
--- a/arraySmlst2ndSmlst.py
+++ b/arraySmlst2ndSmlst.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# 07 Jan 2026 - John R. Weirich
+# Takes multiple outputs from map_coverage_p_low and determines the highest
+# image resolution and the second highest image resolution. Had AI generate it.
+# I checked the results using ISIS 
+
+
+import sys, math
+from itertools import zip_longest
+
+def usage():
+    print(f"Usage: {sys.argv[0]} out_min.txt out_second_min.txt file1.txt [file2.txt ...]")
+    sys.exit(1)
+
+if len(sys.argv) < 4:
+    usage()
+
+out_min, out_second, *inputs = sys.argv[1:]
+fps = [open(p, 'r') for p in inputs]
+
+def parse_row(s):
+    # Parse a line into floats; None for missing/invalid
+    cols = s.strip().split()
+    vals = []
+    for c in cols:
+        try:
+            v = float(c)
+            vals.append(v if not math.isnan(v) else None)
+        except ValueError:
+            vals.append(None)
+    return vals
+
+def min2(values):
+    # Compute smallest and second smallest (second may equal smallest if duplicates).
+    m1 = math.inf
+    m2 = math.inf
+    for v in values:
+        if v < m1:
+            m2 = m1; m1 = v
+        elif v < m2:
+            m2 = v
+    return m1, m2
+
+with open(out_min, 'w') as fmin, open(out_second, 'w') as f2:
+    for rows in zip_longest(*fps, fillvalue=""):
+        parsed = [parse_row(r) if r is not None else [] for r in rows]
+        max_cols = max((len(p) for p in parsed), default=0)
+
+        out_min_row = []
+        out_second_row = []
+
+        for c in range(max_cols):
+            candidates = []
+            for p in parsed:
+                if c < len(p) and p[c] is not None:
+                    candidates.append(p[c])
+
+            if len(candidates) == 0:
+                out_min_row.append("nan"); out_second_row.append("nan")
+            elif len(candidates) == 1:
+                out_min_row.append(f"{candidates[0]}"); out_second_row.append("nan")
+            else:
+                m1, m2 = min2(candidates)
+                out_min_row.append(f"{m1}")
+                out_second_row.append(f"{m2}")
+
+        fmin.write(" ".join(out_min_row) + "\n")
+        f2.write(" ".join(out_second_row) + "\n")
+
+for fp in fps:
+    fp.close()
+

--- a/arraySmlst2ndSmlst.py
+++ b/arraySmlst2ndSmlst.py
@@ -3,7 +3,8 @@
 # Takes multiple outputs from map_coverage_p_low and determines the highest
 # image resolution and the second highest image resolution. Had AI generate it.
 # I checked the results using ISIS 
-
+# 13 Feb 2026 : Now requires 4 arguments (2 out and 2 in), sys.argv counts the
+# 		script name.
 
 import sys, math
 from itertools import zip_longest
@@ -12,7 +13,7 @@ def usage():
     print(f"Usage: {sys.argv[0]} out_min.txt out_second_min.txt file1.txt [file2.txt ...]")
     sys.exit(1)
 
-if len(sys.argv) < 4:
+if len(sys.argv) < 5:
     usage()
 
 out_min, out_second, *inputs = sys.argv[1:]

--- a/avg_best_second.py
+++ b/avg_best_second.py
@@ -1,0 +1,112 @@
+
+#!/usr/bin/env python3
+"""
+Average per-cell values from 'best' and 'second best' grid files.
+
+Usage:
+    python3 avg_best_second.py best.txt second_best.txt [-o out.txt]
+
+Behavior:
+- Lines may have different lengths; averages are computed column-wise up to the longest line.
+- Values are parsed as floats. 'nan' or non-numeric tokens are treated as missing.
+- Averaging rules:
+    * both numeric -> (best + second_best) / 2
+    * one numeric, one missing -> that numeric value
+    * both missing -> nan
+
+Author: M365 Copilot
+"""
+
+# Update 12 Jan 2026 - Instead of checking for None, checks for "9999.".
+
+import sys
+import math
+import argparse
+from itertools import zip_longest
+
+def parse_args():
+    ap = argparse.ArgumentParser(description="Average best and second-best grid files.")
+    ap.add_argument("best", help="Path to best (min) grid file")
+    ap.add_argument("second", help="Path to second-best grid file")
+    ap.add_argument("-o", "--out", help="Output file (defaults to stdout)")
+    ap.add_argument("--delimiter", choices=["space", "tab"], default="space",
+                    help="Delimiter for output (default: space). Input accepts any whitespace.")
+    return ap.parse_args()
+
+def to_float(token):
+    """Return float value or None for missing/non-numeric/nan."""
+    s = token.strip()
+    if not s:
+        return None
+    try:
+        v = float(s)
+        return v if not math.isnan(v) else None
+    except ValueError:
+        return None
+
+def average_pair(a, b):
+    """
+    Average two optional floats:
+    - both <9999 -> arithmetic mean
+    - one <9999 -> returns 9999
+    """
+
+    a_is = isinstance(a, (int, float)) and math.isfinite(a) and a < 9999
+    b_is = isinstance(b, (int, float)) and math.isfinite(b) and b < 9999
+
+    if a_is and b_is:
+        return (float(a) + float(b)) / 2.0
+    elif (not a_is) and (not b_is):
+        return 9999.0
+    else:
+        return 9999.0 
+
+def main():
+    args = parse_args()
+    out_delim = "\t" if args.delimiter == "tab" else " "
+
+    with open(args.best, "r") as f_best, open(args.second, "r") as f_second:
+        lines_best = f_best.readlines()
+        lines_second = f_second.readlines()
+
+    # Stream over the longest file line count
+    out_lines = []
+    for line_best, line_second in zip_longest(lines_best, lines_second, fillvalue=""):
+        # Split on whitespace for input
+        cols_best = line_best.strip().split() if line_best is not None else []
+        cols_second = line_second.strip().split() if line_second is not None else []
+
+        max_cols = max(len(cols_best), len(cols_second))
+        row_out = []
+
+        for c in range(max_cols):
+            tb = cols_best[c] if c < len(cols_best) else ""
+            ts = cols_second[c] if c < len(cols_second) else ""
+
+            vb = to_float(tb)
+            vs = to_float(ts)
+            vavg = average_pair(vb, vs)
+
+            if vavg is None:
+                row_out.append("nan")
+            else:
+                # Format: keep integers tidy, floats concise
+                # Choose a representation: up to 6 significant digits
+                if float(vavg).is_integer():
+                    row_out.append(str(int(vavg)))
+                else:
+                    row_out.append(f"{vavg:.6g}")
+
+        out_lines.append(out_delim.join(row_out))
+
+    if args.out:
+        with open(args.out, "w") as fout:
+            for line in out_lines:
+                fout.write(line + "\n")
+    else:
+        for line in out_lines:
+            print(line)
+
+if __name__ == "__main__":
+    main()
+

--- a/batch_mapcoverage_p_low.sh
+++ b/batch_mapcoverage_p_low.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# 07 Jan 2026 - John R. Weirich
+# Wrapper to generate map_coverage_p_low products for multiple sets of 
+# image lists. Had AI help get it working so you'll see some fancy programming.
+
+# Check if at least one argument is provided
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <bigmap> <file1> [file2 ...]"
+    exit 1
+fi
+
+bigmap=$1 	# First arg: the bigmap
+shift		# Shift so "$@" now contains only filenames
+
+
+echo "10" > tinJRW
+echo $bigmap >> tinJRW
+echo "n" >> tinJRW
+
+
+# Loop through all command-line arguments
+for file in "$@"; do
+
+    echo $file
+    basename="${file##*/}"  # Trim everything left of last "/"
+    echo "$basename"
+   
+    cp -f $file coverage_p.in
+
+/usr/local/spc/bin/map_coverage_p_low < tinJRW
+
+mv ${bigmap}-res.txt ${bigmap}-${basename}-res.txt
+    
+done


### PR DESCRIPTION
Scripts to generate the average of the best and 2nd best image resolutions. This is important for imaging campaigns that have limited viewing geometries where there are a small number of viewing geometries (2 to 5), and the different geometries have large differences in image resolution.

batch_mapcoverage_p_low.sh is used to generate several sets of map_coverage_p_low with the different viewing angles.
arraySmlst2ndSmlst.py is used to generate the best and second best resolution maps
avg_best_second.py averages these two files together, or returns 9999 (i.e. NoData), if one or both are 9999.

A test directory can be found in Dropbox/playground/TigerWEvenOdd_discardAfterSep2026, and the image lists ready to be fed to shell script can be found in Dropbox/playground/TigerWEvenOdd_discardAfterSep2026/forEric. The bigmap to use is BAG351. This latter folder can also be used to dump files (assuming I haven't messed up the permissions).

Please review the code to make sure it isn't doing crazy things (or poor programming standards) and make sure the output looks reasonable. You can compare your output to that in Dropbox/playground/TigerWEvenOdd_discardAfterSep2026/3sunAngles, specifically BAG351_2ndBestRes3Sun.txt, BAG351_bestRes3Sun.txt, BAG351_avgBest2ndBest3Sun.txt. There's also the cub files I generated from the txt files. For the files with "Mask", I've turned 9999.0 into null pixels to make the stretch in ISIS look better.